### PR TITLE
Errors and timeout

### DIFF
--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -444,10 +444,13 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
                 }
                 else {
                     // error
-                    UIApplication.shared.isNetworkActivityIndicatorVisible = false
-                    self.delegate?.HPPManagerFailedWithError!(error! as NSError)
-                    self.genericDelegate?.HPPManagerFailedWithError(error)
-                    self.hppViewController.dismiss(animated: true, completion: nil)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: { [weak self] in
+                        // Allow 0.5s for hppViewController to present, before dismissing
+                        UIApplication.shared.isNetworkActivityIndicatorVisible = false
+                        self?.delegate?.HPPManagerFailedWithError!(error! as NSError)
+                        self?.genericDelegate?.HPPManagerFailedWithError(error)
+                        self?.hppViewController.dismiss(animated: true, completion: nil)
+                    })
                 }
 
             } catch {

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -551,7 +551,7 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
      */
 
     func HPPViewControllerFailedWithError(_ error: NSError?) {
-        self.delegate?.HPPManagerFailedWithError!(error as NSError?)
+        self.delegate?.HPPManagerFailedWithError!(error)
         self.genericDelegate?.HPPManagerFailedWithError(error)
         self.hppViewController.dismiss(animated: true, completion: nil)
     }

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -547,7 +547,7 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
      - parameter error: The error which occured.
      */
 
-    private func HPPViewControllerFailedWithError(_ error: Error?) {
+    func HPPViewControllerFailedWithError(_ error: NSError?) {
         self.delegate?.HPPManagerFailedWithError!(error as NSError?)
         self.genericDelegate?.HPPManagerFailedWithError(error)
         self.hppViewController.dismiss(animated: true, completion: nil)

--- a/Pod/Classes/RealexComponent/HPPViewController.swift
+++ b/Pod/Classes/RealexComponent/HPPViewController.swift
@@ -30,8 +30,8 @@ class HPPViewController: UIViewController, WKNavigationDelegate,  WKUIDelegate, 
     /**
      Initialise the correct webview for the OS version being run on.
      */
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
 
         if #available(iOS 9.0, *) {
             // use WKWebView on iOS 9.0 and later


### PR DESCRIPTION
### In this PR:
- One of the optional `HPPViewControllerDelegate` method implementations in `HPPManager` had an incorrect parameter type, and therefore didn't conform to the delegate protocol. When the expected method was called from `HPPViewController`, it was force-unwrapped and found to be `nil`, causing a crash. The method parameter has been updated.
- A delay has been added when dismissing `HPPViewController`, to ensure that the view controller is always dismissed after it has been presented.
- The webview in `HPPViewController` is now setup on `viewWillAppear` instead of `viewDidLoad`. This ensures that the user will not see the previous state of the webview (including a CVV code that may have been perviously entered).
- When tapping the 'Pay Now' button, a JavaScript timeout has been added to ensure that the screen doesn't hang (previously, if the network call failed, the screen would hang).

### Still to do:
- Implement a retry mechanism for the `/callback/globalpayments` call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/rxp-ios/7)
<!-- Reviewable:end -->
