### PR TITLE
Retry mechanism for HPP Response Consumer network request

### DIFF
--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -547,6 +547,9 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
      Retry mechanism for data tasks.
      */
     private func retry(times: Int = 4, delay: TimeInterval = 0.5, task: @escaping (@escaping DataTaskCallback) -> Void, finalCallback: @escaping DataTaskCallback) {
+        if times <= 0 {
+            return
+        }
         task() { [weak self] result in
             self?.currentDataTask?.cancel()
             switch result {

--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -12,7 +12,7 @@ import UIKit
     @objc optional func HPPManagerCompletedWithResult(_ result: Dictionary <String, String>);
     @objc optional func HPPManagerFailedWithError(_ error: NSError?);
     @objc optional func HPPManagerCancelled();
-
+    @objc optional func HPPManagerDismissed();
 }
 
 /**
@@ -559,9 +559,13 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
     /**
      The delegate callback made by the HPP View controller when the user cancels the payment.
      */
-    func HPPViewControllerWillDismiss() {
+    func HPPViewControllerWillCancel() {
         self.delegate?.HPPManagerCancelled!()
         self.genericDelegate?.HPPManagerCancelled()
+    }
+
+    func HPPViewControllerWillDismiss() {
+        self.delegate?.HPPManagerDismissed?()
     }
 
 }

--- a/Pod/Classes/RealexComponent/HPPViewController.swift
+++ b/Pod/Classes/RealexComponent/HPPViewController.swift
@@ -10,6 +10,7 @@ import WebKit
  *  THe delegate callbacks which allow the HPPManager to receive back the results from the webview.
  */
 @objc protocol HPPViewControllerDelegate {
+    @objc optional func HPPViewControllerWillCancel()
     @objc optional func HPPViewControllerWillDismiss()
     @objc optional func HPPViewControllerCompletedWithResult(_ result: String);
     @objc optional func HPPViewControllerFailedWithError(_ error: NSError?);
@@ -95,7 +96,7 @@ class HPPViewController: UIViewController, WKNavigationDelegate,  WKUIDelegate, 
      Called if the user taps the cancel button.
      */
     @objc func closeView() {
-        self.delegate?.HPPViewControllerWillDismiss!()
+        self.delegate?.HPPViewControllerWillCancel?()
         self.dismiss(animated: true, completion: nil)
     }
 
@@ -207,6 +208,7 @@ class HPPViewController: UIViewController, WKNavigationDelegate,  WKUIDelegate, 
             self.delegate?.HPPViewControllerFailedWithError!(nil)
         }
 
+        delegate?.HPPViewControllerWillDismiss?()
         self.dismiss(animated: true, completion: nil)
         webView = nil
     }
@@ -224,6 +226,7 @@ class HPPViewController: UIViewController, WKNavigationDelegate,  WKUIDelegate, 
 
                 let message = request.url?.host!.removingPercentEncoding
                 self.delegate?.HPPViewControllerCompletedWithResult!(message!)
+                self.delegate?.HPPViewControllerWillDismiss?()
                 self.dismiss(animated: true, completion: nil)
             }
             return true


### PR DESCRIPTION
- Added a retry mechanism to the HPP Response Consumer network request. The retry will fire if the request times out or fails, up to a predefined number of times.
- Separated the `HPPViewControllerWillDismiss` protocol method into a `HPPViewControllerWillDismiss` method and a `HPPViewControllerWillCancel` method. This allows handling of the case where the view controller is dismissed before any network tasks have completed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/rxp-ios/8)
<!-- Reviewable:end -->
