### PR TITLE
Update HPPViewController to only fire timeout handler if the payment …

### DIFF
--- a/Pod/Classes/RealexComponent/HPPViewController.swift
+++ b/Pod/Classes/RealexComponent/HPPViewController.swift
@@ -53,15 +53,29 @@ class HPPViewController: UIViewController, WKNavigationDelegate,  WKUIDelegate, 
      */
     fileprivate func initialiseWebView() {
 
-        let viewScriptString = "var meta = document.createElement('meta'); meta.setAttribute('name', 'viewport'); meta.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum- scale=1.0, user-scalable=no'); document.getElementsByTagName('head')[0].appendChild(meta);";
+        let viewScriptString = """
+        var meta = document.createElement('meta'); meta.setAttribute('name', 'viewport');
+        meta.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum- scale=1.0, user-scalable=no');
+        document.getElementsByTagName('head')[0].appendChild(meta);
+        """
         let viewScript = WKUserScript(source: viewScriptString, injectionTime: .atDocumentStart, forMainFrameOnly: true)
 
         let timeout = 5000
         let timeoutScriptString = """
         document.getElementById('rxp-primary-btn').addEventListener('click', function() {
-          setTimeout( function() {
-            window.webkit.messageHandlers.timeoutHandler.postMessage('timeout')
-        }, \(timeout));
+          // Create timeout callback
+          var timeoutCallback = function() {
+            setTimeout( function() {
+                window.webkit.messageHandlers.timeoutHandler.postMessage('timeout');
+            }, \(timeout));
+          }
+
+          // Wait 100ms to ensure primary button will have transitioned to disabled state
+          setTimeout(function() {
+            if (document.getElementById('rxp-primary-btn').disabled) {
+              timeoutCallback();
+            }
+          }, 100);
         });
         """
         let timeoutScript = WKUserScript(source: timeoutScriptString, injectionTime: .atDocumentEnd, forMainFrameOnly: true)


### PR DESCRIPTION
**Context:**
On the card payment screen, the JavaScript timeout handler was firing whenever the user tapped the 'Pay Now' button, overriding the form validation.

**In this PR:**
The injected JavaScript has been adjusted to only fire the timeout handler if the 'Pay Now' button is disabled (ie. when the form has been submitted)

**Other comments**
This may not be the best way to handle the timeout. I'm open to any better suggestions!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/rxp-ios/9)
<!-- Reviewable:end -->
