### PR TITLE
Fullscreen modal for iOS 13

### DIFF
--- a/Pod/Classes/RealexComponent/HPPManager.swift
+++ b/Pod/Classes/RealexComponent/HPPManager.swift
@@ -296,6 +296,7 @@ open class GenericHPPManager<T: Decodable>: NSObject, UIWebViewDelegate, HPPView
         if  self.HPPRequestProducerURL.absoluteString != "" {
             self.getHPPRequest()
             let navigationController = UINavigationController(rootViewController: self.hppViewController)
+            navigationController.modalPresentationStyle = .fullScreen
             viewController.present(navigationController, animated: true, completion: nil)
         } else {
             // error


### PR DESCRIPTION
### Context:
In iOS 13, modals are presented as dismissible 'cards' by default, causing the `HPPViewController` to be dismissed without calling the relevant delegate method. The view controller should be presented fullscreen.

### In this PR:
- Set `HPPViewController.modalPresentationStyle` to `.fullscreen` before presenting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/brightec/rxp-ios/11)
<!-- Reviewable:end -->
